### PR TITLE
Add SQL `IN` condition handler

### DIFF
--- a/modules/db-access/src/main/kotlin/info/vividcode/orm/RelationPredicates.kt
+++ b/modules/db-access/src/main/kotlin/info/vividcode/orm/RelationPredicates.kt
@@ -17,6 +17,12 @@ sealed class RelationPredicate<T : Any> {
     class Eq<T : Any, R : Any>(val type: KClass<T>, val property: KProperty1<T, R>, val value: R) :
         RelationPredicate<T>()
 
+    /**
+     * This class represents SQL `in` condition.
+     */
+    class In<T : Any, R : Any>(val type: KClass<T>, val property: KProperty1<T, R>, val value: List<R>) :
+        RelationPredicate<T>()
+
     class IsNull<T : Any, R>(val type: KClass<T>, val property: KProperty1<T, R>) :
         RelationPredicate<T>()
 
@@ -26,6 +32,11 @@ sealed class RelationPredicate<T : Any> {
 }
 
 object RelationPredicateBuilder {
+
+    /**
+     * Create [Prop] for [property]. Created value can be used for [in] method.
+     */
+    inline fun <reified T : Any, R> p(property: KProperty1<T, R>) = Prop(T::class, property)
 
     inline infix fun <reified T : Any> KProperty1<T, Long>.eq(d: Long): RelationPredicate<T> {
         return RelationPredicate.Eq(T::class, this, d)
@@ -39,6 +50,14 @@ object RelationPredicateBuilder {
         return RelationPredicate.Eq(T::class, this, d)
     }
 
+    /**
+     * Create a object which represents SQL `in` condition.
+     *
+     * @param v List of target values. If this is empty list, this condition will be always false.
+     */
+    infix fun <T : Any, E : Any> Prop<T, E>.`in`(v: List<E>): RelationPredicate<T> =
+        RelationPredicate.In(this.receiverClass, this.property, v)
+
     fun <T : Any, R : Any> of(
         c: (T) -> R,
         builder: RelationPredicateBuilder.() -> RelationPredicate<R>
@@ -49,5 +68,16 @@ object RelationPredicateBuilder {
         get() {
             return RelationPredicate.IsNull(T::class, this)
         }
+
+    /**
+     * This class represents a property.
+     *
+     * Type parameter of [KProperty1] which represents type of property is out variant.
+     * So that type inference for [KProperty1] doesn't work well. Type inference for [Prop] works well.
+     *
+     * @param T The type of the receiver which should be used to obtain the value of the property.
+     * @param R The type of the property. It's not out variant.
+     */
+    class Prop<T : Any, R>(val receiverClass: KClass<T>, val property: KProperty1<T, R>)
 
 }

--- a/modules/db-access/src/main/kotlin/info/vividcode/orm/db/RelationPredicates.kt
+++ b/modules/db-access/src/main/kotlin/info/vividcode/orm/db/RelationPredicates.kt
@@ -12,6 +12,14 @@ fun <T : Any> RelationPredicate<T>.toSqlWhereClause(mappingInfoRegistry: TupleCl
             val columnName = mappingInfoRegistry.getTupleClass(this.type).findAttributeNameFromProperty(this.property)
             WhereClause("\"$columnName\" = ?", listOf(valueSetter(this@toSqlWhereClause.value)))
         }
+        is RelationPredicate.In<T, *> -> {
+            if (value.isEmpty()) {
+                WhereClause("1 <> 1", emptyList())
+            } else {
+                val columnName = mappingInfoRegistry.getTupleClass(type).findAttributeNameFromProperty(this.property)
+                WhereClause("\"$columnName\" IN (${value.joinToString(",") { "?" }})", value.map(::valueSetter))
+            }
+        }
         is RelationPredicate.IsNull<T, *> -> {
             val columnName = mappingInfoRegistry.getTupleClass(this.type).findAttributeNameFromProperty(this.property)
             WhereClause("\"$columnName\" IS NULL", emptyList())

--- a/modules/db-access/src/test/kotlin/info/vividcode/orm/db/RelationPredicateTest.kt
+++ b/modules/db-access/src/test/kotlin/info/vividcode/orm/db/RelationPredicateTest.kt
@@ -4,6 +4,7 @@ import info.vividcode.orm.AttributeName
 import info.vividcode.orm.TupleClassRegistry
 import info.vividcode.orm.where
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import java.sql.PreparedStatement
@@ -84,6 +85,140 @@ internal class RelationPredicateTest {
         Mockito.verifyNoMoreInteractions(preparedStatement)
     }
 
+    @Nested
+    internal inner class InCondition {
+        private val sqlConditionAlwaysFalse = "1 <> 1"
+
+        @Test
+        internal fun int_singleElement() {
+            val predicate = where { p(TestTuple.Content::test2) `in` listOf(100) }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"test_2\" IN (?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(1, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 100)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun int_multipleElements() {
+            val predicate = where { p(TestTuple.Content::test2) `in` listOf(100, 200, 300) }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"test_2\" IN (?,?,?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(3, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setInt(1, 100)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setInt(2, 200)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setInt(3, 300)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun int_empty() {
+            val predicate = where { p(TestTuple.Content::test2) `in` emptyList() }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals(sqlConditionAlwaysFalse, sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(0, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun long_singleElement() {
+            val predicate = where { p(TestTuple::id) `in` listOf(100L) }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"id\" IN (?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(1, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setLong(1, 100L)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun long_multipleElements() {
+            val predicate = where { p(TestTuple::id) `in` listOf(100L, 200L, 300L) }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"id\" IN (?,?,?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(3, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setLong(1, 100)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setLong(2, 200)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setLong(3, 300)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun long_empty() {
+            val predicate = where { p(TestTuple::id) `in` emptyList() }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals(sqlConditionAlwaysFalse, sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(0, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun string_singleElement() {
+            val predicate = where { p(TestTuple.Content::test1) `in` listOf("A") }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"test1\" IN (?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(1, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, "A")
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun string_multipleElements() {
+            val predicate = where { p(TestTuple.Content::test1) `in` listOf("A", "B", "C") }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals("\"test1\" IN (?,?,?)", sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(3, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verify(preparedStatement, Mockito.times(1)).setString(1, "A")
+            Mockito.verify(preparedStatement, Mockito.times(1)).setString(2, "B")
+            Mockito.verify(preparedStatement, Mockito.times(1)).setString(3, "C")
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+
+        @Test
+        internal fun string_empty() {
+            val predicate = where { p(TestTuple.Content::test1) `in` emptyList() }
+
+            val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
+            Assertions.assertEquals(sqlConditionAlwaysFalse, sqlWhereClause.whereClauseString)
+            Assertions.assertEquals(0, sqlWhereClause.valueSetterList.size)
+
+            val preparedStatement = Mockito.mock(PreparedStatement::class.java)
+            invokeValueSetterList(preparedStatement, sqlWhereClause.valueSetterList)
+            Mockito.verifyNoMoreInteractions(preparedStatement)
+        }
+    }
+
     @Test
     fun isNull() {
         val predicate = where {
@@ -93,6 +228,12 @@ internal class RelationPredicateTest {
         val sqlWhereClause = predicate.toSqlWhereClause(tupleClassRegistry)
         Assertions.assertEquals("\"test1\" IS NULL", sqlWhereClause.whereClauseString)
         Assertions.assertEquals(0, sqlWhereClause.valueSetterList.size)
+    }
+
+    private fun invokeValueSetterList(
+        preparedStatement: PreparedStatement, valueSetterList: List<PreparedStatement.(Int) -> Unit>
+    ) {
+        valueSetterList.forEachIndexed { index, function -> function.invoke(preparedStatement, index + 1) }
     }
 
 }


### PR DESCRIPTION
# Usage

```kotlin
val users = usersRelation.select(where { p(UserTuple::id) `in` listOf(1L, 2L, 3L) }).toSet()
```

# Detail

## `Prop` class is introduced

You using `KProperty1` object directly, the declaration of `in` method will be following:

```kotlin
infix fun <reified T : Any, E : Any> KProperty1<T, E>.`in`(v: List<E>): RelationPredicate<T> =
        RelationPredicate.In(T::class, this, v)
```

With this declaration, the type inference for `E` doesn't work well, because `E` of KProperty1 is out variant. To avoid this problem, `Prop` class is introduced

# Acknowledgement

* Thanks @jmatsu! ( https://twitter.com/red_fat_daruma/status/1023170166543212545 )