### PR TITLE
Change waiting time for test environment on CircleCI to 20 seconds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           command: docker pull quay.io/wakaba/firefoxdriver:stable
 
       - run:
+          name: Run application for test
           background: true
           command: |
             set +e
@@ -76,11 +77,12 @@ jobs:
             # Java application terminated by signal returns exit code 143
             if [ $s -eq 0 -o $s -eq 143 ]; then exit 0; else exit $s; fi
       - run:
+          name: Run WebDriver remote end for test
           background: true
           command: docker run -it --rm --network=host --name sbs-wd-firefox quay.io/wakaba/firefoxdriver:stable /fx
       - run:
-          name: Wait for test enviroment
-          command: sleep 3
+          name: Wait for test target application and test enviroment
+          command: sleep 20
       - run:
           name: Run system test
           command: docker run -it --rm --network=host --name sbs-system-test sbs-system-test


### PR DESCRIPTION
3 seconds are too short so that test sometimes fails.